### PR TITLE
Add tools that exist in devopsbookmarks.com but not .org

### DIFF
--- a/data/tools/akeyless-vault.json
+++ b/data/tools/akeyless-vault.json
@@ -1,0 +1,18 @@
+[
+  {
+    "description": "Secrets Management: Automate Secrets across your DevOps tools and cloud platforms using a secured vault for credentials, tokens, API-Keys and passwords.",
+    "name": "Akeyless Vault",
+    "slug": "Akeyless",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "bsd",
+      "solaris",
+      "free",
+      "commercial",
+      "security"
+    ],
+    "url": "https://www.akeyless.io/"
+  }
+]

--- a/data/tools/apache-allura.json
+++ b/data/tools/apache-allura.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Apache Allura is an open source implementation of a software forge, a web site that manages source code repositories, bug reports, discussions, wiki pages, blogs, and more for any number of individual projects.",
+    "name": "Apache Allura",
+    "slug": "apache-allura",
+    "tags": [
+      "linux",
+      "open-source",
+      "scm",
+      "vcs"
+    ],
+    "url": "http://allura.apache.org/"
+  }
+]

--- a/data/tools/archiva.json
+++ b/data/tools/archiva.json
@@ -1,0 +1,17 @@
+[
+  {
+    "description": "Apache Archiva™ is an extensible repository management software that helps taking care of your own personal or enterprise-wide build artifact repository.",
+    "name": "Archiva",
+    "slug": "archiva",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "bsd",
+      "solaris",
+      "open-source",
+      "artifacts"
+    ],
+    "url": "http://archiva.apache.org"
+  }
+]

--- a/data/tools/artifactory.json
+++ b/data/tools/artifactory.json
@@ -1,0 +1,15 @@
+[
+  {
+    "description": "JFrog’s Artifactory open source project was created to speed up development cycles using binary repositories. It’s the world’s most advanced repository manager, creating a single place for teams to manage all their binary artifacts efficiently.",
+    "name": "Artifactory",
+    "slug": "artifactory",
+    "tags": [
+      "linux",
+      "windows",
+      "open-source",
+      "artifacts",
+      "packaging"
+    ],
+    "url": "https://jfrog.com/open-source/"
+  }
+]

--- a/data/tools/assimilation.json
+++ b/data/tools/assimilation.json
@@ -1,0 +1,23 @@
+[
+  {
+    "description": "The Assimilation Suite discovers systems, services, network connections, configuration and dependencies, IP and MAC addresses. This all goes into a continually updated graph-based configuration management database (CMDB).  This is then compared and scored against best practices, services and servers are monitored - all with near-zero configuration - in a way that scales to hundreds of thousands of servers.\nIt also provides visualization tools, APIs for sending alerts to humans and other systems, and a variety of canned reports (queries) to aid in securing and managing systems, hooking into ChatOps, and creating plans for triaging your security issues",
+    "name": "Assimilation System Management Suite",
+    "slug": "assimilation",
+    "tags": [
+      "linux",
+      "open-source",
+      "commercial",
+      "C",
+      "shell",
+      "python",
+      "config",
+      "CMDB",
+      "service-discovery",
+      "monitoring",
+      "visualization",
+      "security",
+      "hardening"
+    ],
+    "url": "http://AssimilationSystems.com/"
+  }
+]

--- a/data/tools/bastillion.json
+++ b/data/tools/bastillion.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "Bastillion is an open-source web-based SSH console that centrally manages administrative access to systems. A bastion host for administrators with features that promote infrastructure security, including key management and auditing.",
+    "name": "Bastillion",
+    "slug": "Bastillion",
+    "tags": [
+      "linux",
+      "open-source",
+      "security"
+    ],
+    "url": "https://www.bastillion.io/"
+  }
+]

--- a/data/tools/beats.json
+++ b/data/tools/beats.json
@@ -1,0 +1,17 @@
+[
+  {
+    "description": "Lightweight Data Shippers. Beats is the platform for single-purpose data shippers. They send data from hundreds or thousands of machines and systems to Logstash or Elasticsearch.",
+    "name": "Beats",
+    "slug": "beats",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "metrics",
+      "logging",
+      "monitoring"
+    ],
+    "url": "https://www.elastic.co/products/beats"
+  }
+]

--- a/data/tools/cft.json
+++ b/data/tools/cft.json
@@ -1,0 +1,15 @@
+[
+  {
+    "description": "Cft watches as you make changes to your server, and then creates puppet manifests for the resulting actions. Simplifies creating puppet configuration.",
+    "name": "Cft",
+    "slug": "cft",
+    "tags": [
+      "linux",
+      "open-source",
+      "config-mgmt",
+      "provisioning",
+      "orchestration"
+    ],
+    "url": "https://gitorious.org/cft/cft"
+  }
+]

--- a/data/tools/chartmuseum.json
+++ b/data/tools/chartmuseum.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Host your own Helm Chart Repository ChartMuseum is an open-source, easy to deploy, Helm Chart Repository server.",
+    "name": "ChartMuseum",
+    "slug": "chartmuseum",
+    "tags": [
+      "linux",
+      "open-source",
+      "packaging",
+      "artifacts"
+    ],
+    "url": "https://chartmuseum.com/"
+  }
+]

--- a/data/tools/checkov.json
+++ b/data/tools/checkov.json
@@ -1,0 +1,15 @@
+[
+  {
+    "description": "Infrastructure as Code security scanner supporting Kubernetes, Helm, Terraform, CloudFormation, ARM templates and more.",
+    "name": "Checkov",
+    "slug": "checkov",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "security"
+    ],
+    "url": "https://checkov.io"
+  }
+]

--- a/data/tools/condep.json
+++ b/data/tools/condep.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "ConDep is a open source infrastructure configuration and deployment DSL (Domain Specific Language) specifically targeted to (but not limited to) the Windows Server platform. If your familiar with tools like Chef and Puppet, ConDep does very much the same, but with native support for Windows.",
+    "name": "ConDep",
+    "slug": "condep",
+    "tags": [
+      "windows",
+      "open-source",
+      "ci",
+      "provisioning",
+      "config-mgmt",
+      "net"
+    ],
+    "url": "http://www.condep.io/"
+  }
+]

--- a/data/tools/configcat.json
+++ b/data/tools/configcat.json
@@ -1,0 +1,26 @@
+[
+  {
+    "description": "ConfigCat is a feature flags as a service. It gives you a web based dashboard to manage your feature flags + SDKs to integrate those feature flags into your applications. ConfigCat enables you to use the same feature flags in your mobile apps, websites and server-side applications. It offers all features for free. You get an enterprise-ready SLA with the pricing plans.",
+    "name": "ConfigCat",
+    "slug": "configcat",
+    "tags": [
+      "linux",
+      "osx",
+      "windows",
+      "open-source",
+      "free",
+      "commercial",
+      "ci",
+      "cd",
+      "config-management",
+      "go",
+      "java",
+      "net",
+      "nodejs",
+      "php",
+      "python",
+      "ruby"
+    ],
+    "url": "https://configcat.com"
+  }
+]

--- a/data/tools/coveralls.json
+++ b/data/tools/coveralls.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "Coveralls works with your continuous integration server to give you test coverage history and statistics. Free for open source, pro accounts for private repos, instant sign up with GitHub OAuth.",
+    "name": "Coveralls",
+    "slug": "coveralls",
+    "tags": [
+      "free",
+      "commercial",
+      "ci"
+    ],
+    "url": "https://coveralls.io"
+  }
+]

--- a/data/tools/crio.json
+++ b/data/tools/crio.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "CRI-O is an implementation of the Kubernetes CRI (Container Runtime Interface) to enable using OCI (Open Container Initiative) compatible runtimes. It is a lightweight alternative to using Docker as the runtime for kubernetes. It allows Kubernetes to use any OCI-compliant runtime as the container runtime for running pods. Today it supports runc and Kata Containers as the container runtimes but any OCI-conformant runtime can be plugged in principle. CRI-O supports OCI container images and can pull from any container registry. It is a lightweight alternative to using Docker, Moby or rkt as the runtime for Kubernetes.",
+    "name": "CRI-O",
+    "slug": "crio",
+    "tags": [
+      "linux",
+      "open-source",
+      "virt"
+    ],
+    "url": "https://cri-o.io/"
+  }
+]

--- a/data/tools/crossplane.json
+++ b/data/tools/crossplane.json
@@ -1,0 +1,20 @@
+[
+  {
+    "description": "Crossplane, a Cloud Native Computing Foundation sandbox project, is an open source Kubernetes add-on that extends any cluster with the ability to provision and manage cloud infrastructure, services, and applications using kubectl, GitOps, or any tool that works with the Kubernetes API.",
+    "name": "Crossplane",
+    "slug": "crossplane",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "provisioning",
+      "orchestration",
+      "automation",
+      "open-source",
+      "free",
+      "commercial"
+    ],
+    "url": "https://crossplane.io/"
+  }
+]

--- a/data/tools/dist.json
+++ b/data/tools/dist.json
@@ -1,0 +1,17 @@
+[
+  {
+    "description": "Private, fully managed Docker Container Registries and Maven Repositories. Works with native tooling, no plugins required. Reliable, secure, and fast (with a purpose built CDN).",
+    "name": "Dist",
+    "slug": "dist",
+    "tags": [
+      "linux",
+      "cloud",
+      "packaging",
+      "maven",
+      "java",
+      "clojure",
+      "scala"
+    ],
+    "url": "https://dist.cloud"
+  }
+]

--- a/data/tools/draft.json
+++ b/data/tools/draft.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Streamlined Kubernetes Development. Simple app development & deployment - into any Kubernetes cluster.",
+    "name": "Draft",
+    "slug": "draft",
+    "tags": [
+      "linux",
+      "open-source",
+      "ci",
+      "cd"
+    ],
+    "url": "https://draft.sh/"
+  }
+]

--- a/data/tools/elasticsearch.json
+++ b/data/tools/elasticsearch.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "<Description>",
+    "name": "Elasticsearch",
+    "slug": "elasticsearch",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "logging",
+      "monitoring"
+    ],
+    "url": "https://www.elastic.co/products/elasticsearch"
+  }
+]

--- a/data/tools/gitbucket.json
+++ b/data/tools/gitbucket.json
@@ -1,0 +1,19 @@
+[
+  {
+    "description": "A Git platform powered by Scala with easy installation, high extensibility & GitHub API compatibility.",
+    "name": "GitBucket",
+    "slug": "gitbucket",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "bsd",
+      "solaris",
+      "open-source",
+      "scm",
+      "vcs",
+      "ci"
+    ],
+    "url": "https://gitbucket.github.io/"
+  }
+]

--- a/data/tools/gitea.json
+++ b/data/tools/gitea.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "Gitea is a community managed lightweight code hosting solution written in Go. It published under the MIT license. ",
+    "name": "gitea",
+    "slug": "gitea",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "scm",
+      "vcs"
+    ],
+    "url": "https://gitea.io/"
+  }
+]

--- a/data/tools/google-docs.json
+++ b/data/tools/google-docs.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "A powerful document creation platform. Supports features such as: realtime collaboration, offline document editing, inline document comments, search and full differential changelog. Free for personal use, costs for commercial",
+    "name": "Google Docs",
+    "slug": "google-docs",
+    "tags": [
+      "documentation",
+      "free",
+      "commercial"
+    ],
+    "url": "http://www.google.com/docs/about/"
+  }
+]

--- a/data/tools/hackpad.json
+++ b/data/tools/hackpad.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "A lightweight, markdown based, document creation platform packed full of features such as: realtime collaboration, offline document reading (via dropbox), in documment comments, search / tagging and full diff'd changelog. Private workspaces free for the first 5 users, Public workspaces always free.",
+    "name": "Hackpad",
+    "slug": "hackpad",
+    "tags": [
+      "documentation",
+      "free",
+      "commercial"
+    ],
+    "url": "http://www.hackpad.com/"
+  }
+]

--- a/data/tools/hexadecimal.json
+++ b/data/tools/hexadecimal.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "No-nonsense website monitoring and status page service",
+    "name": "Hexadecimal",
+    "slug": "hexadecimal",
+    "tags": [
+      "commercial",
+      "monitoring",
+      "errors"
+    ],
+    "url": "https://tryhexadecimal.com"
+  }
+]

--- a/data/tools/intelliment.json
+++ b/data/tools/intelliment.json
@@ -1,0 +1,17 @@
+[
+  {
+    "description": "Intelliment is a platform to allow enterprises to automate their network security policy management in order to help them better handle their security at scale and to respond faster to network threats",
+    "name": "Intelliment Security Policy Automation",
+    "slug": "intelliment",
+    "tags": [
+      "linux",
+      "commercial",
+      "security",
+      "orchestration",
+      "provisioning",
+      "networking",
+      "firewall"
+    ],
+    "url": "http://www.intellimentsec.com"
+  }
+]

--- a/data/tools/jenkins-x.json
+++ b/data/tools/jenkins-x.json
@@ -1,0 +1,19 @@
+[
+  {
+    "description": "Jenkins X provides pipeline automation, built-in GitOps and preview environments to help teams collaborate and accelerate their software delivery at any scale.",
+    "name": "Jenkins X",
+    "slug": "jenkinsx",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "ci",
+      "cd",
+      "artifacts",
+      "packaging",
+      "provisioning"
+    ],
+    "url": "https://jenkins-x.io/"
+  }
+]

--- a/data/tools/kallithea.json
+++ b/data/tools/kallithea.json
@@ -1,0 +1,15 @@
+[
+  {
+    "description": "Kallithea, a member project of Software Freedom Conservancy, is a GPLv3'd, Free Software source code management system that supports two leading version control systems, Mercurial and Git, and has a web interface that is easy to use for users and admins. You can install Kallithea on your own server and host repositories for the version control system of your choice.",
+    "name": "Kallithea",
+    "slug": "kallithea",
+    "tags": [
+      "linux",
+      "windows",
+      "open-source",
+      "scm",
+      "vcs"
+    ],
+    "url": "https://kallithea-scm.org/"
+  }
+]

--- a/data/tools/laminar.json
+++ b/data/tools/laminar.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "Laminar is a lightweight and modular Continuous Integration service for Linux. It is self-hosted and developer-friendly, eschewing a configuration web UI in favor of simple version-controllable configuration files and scripts.",
+    "name": "Laminar",
+    "slug": "laminar",
+    "tags": [
+      "linux",
+      "open-source",
+      "ci"
+    ],
+    "url": "https://laminar.ohwg.net/"
+  }
+]

--- a/data/tools/minikube.json
+++ b/data/tools/minikube.json
@@ -1,0 +1,15 @@
+[
+  {
+    "description": "minikube implements a local Kubernetes cluster on macOS, Linux, and Windows.",
+    "name": "minikube",
+    "slug": "minikube",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "virt"
+    ],
+    "url": "https://github.com/kubernetes/minikube"
+  }
+]

--- a/data/tools/monocular.json
+++ b/data/tools/monocular.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "Monocular is a web-based application that enables the search and discovery of charts from multiple Helm Chart repositories. It is the codebase that powers the Helm Hub project.",
+    "name": "Monocular",
+    "slug": "monocular",
+    "tags": [
+      "linux",
+      "open-source",
+      "service-discovery"
+    ],
+    "url": "https://github.com/helm/monocular"
+  }
+]

--- a/data/tools/nevercode.json
+++ b/data/tools/nevercode.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Develop apps 20% faster with the leading CI/CD partner Cloud-based continuous integration & delivery for iOS, Android, Cordova, Ionic, React Native & Flutter projects.",
+    "name": "Nevercode",
+    "slug": "nevercode",
+    "tags": [
+      "cloud",
+      "commercial",
+      "ci",
+      "cd"
+    ],
+    "url": "https://nevercode.io/"
+  }
+]

--- a/data/tools/nixops.json
+++ b/data/tools/nixops.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "NixOps is a tool for deploying sets of NixOS Linux machines, either to real hardware or to virtual machines. It extends NixOS’s declarative approach to system configuration management to networks and adds provisioning.",
+    "name": "NixOps",
+    "slug": "nixops",
+    "tags": [
+      "linux",
+      "open-source",
+      "provisioning"
+    ],
+    "url": "https://nixos.org/nixops/"
+  }
+]

--- a/data/tools/nomad.json
+++ b/data/tools/nomad.json
@@ -1,0 +1,17 @@
+[
+  {
+    "description": "Nomad is a lightweight workload orchestrator. It offers client instance scaling as well as workload scaling.",
+    "name": "Nomad",
+    "slug": "nomad",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "virt",
+      "orchestration",
+      "go"
+    ],
+    "url": "https://github.com/hashicorp/nomad"
+  }
+]

--- a/data/tools/notabug.json
+++ b/data/tools/notabug.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Free code hosting",
+    "name": "notabug.org",
+    "slug": "notabug",
+    "tags": [
+      "cloud",
+      "open-source",
+      "scm",
+      "vcs"
+    ],
+    "url": "https://notabug.org/"
+  }
+]

--- a/data/tools/okd.json
+++ b/data/tools/okd.json
@@ -1,0 +1,15 @@
+[
+  {
+    "description": "<Description>",
+    "name": "okd",
+    "slug": "okd",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "virt"
+    ],
+    "url": "https://www.okd.io"
+  }
+]

--- a/data/tools/onedev.json
+++ b/data/tools/onedev.json
@@ -1,0 +1,18 @@
+[
+  {
+    "description": "The open source git server with unique features.",
+    "name": "OneDev",
+    "slug": "onedev",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "bsd",
+      "solaris",
+      "open-source",
+      "scm",
+      "vcs"
+    ],
+    "url": "https://onedev.io/"
+  }
+]

--- a/data/tools/openbuildservice.json
+++ b/data/tools/openbuildservice.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Build and distribute Linux packages from sources in an automatic, consistent and reproducible way",
+    "name": "Open Build Service",
+    "slug": "obs",
+    "tags": [
+      "linux",
+      "open-source",
+      "cd",
+      "open-source"
+    ],
+    "url": "http://openbuildservice.org/"
+  }
+]

--- a/data/tools/pallet.json
+++ b/data/tools/pallet.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "A tool to provision and maintain servers across various cloud platforms as well as virtual machine platforms, without any dependencies. Provides cloud and operating system independence.",
+    "name": "Pallet",
+    "slug": "pallet",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "cloud-paas",
+      "clojure"
+    ],
+    "url": "http://palletops.com/"
+  }
+]

--- a/data/tools/podman.json
+++ b/data/tools/podman.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "Podman is a daemonless container engine for developing, managing, and running OCI Containers on your Linux System. Containers can either be run as root or in rootless mode. Simply put: `alias docker=podman`.",
+    "name": "Podman",
+    "slug": "podman",
+    "tags": [
+      "linux",
+      "open-source",
+      "virt"
+    ],
+    "url": "https://podman.io"
+  }
+]

--- a/data/tools/prow.json
+++ b/data/tools/prow.json
@@ -1,0 +1,15 @@
+[
+  {
+    "description": "row is a Kubernetes based CI/CD system. Jobs can be triggered by various types of events and report their status to many different services. In addition to job execution, Prow provides GitHub automation in the form of policy enforcement, chat-ops via /foo style commands, and automatic PR merging.",
+    "name": "Prow",
+    "slug": "prow",
+    "tags": [
+      "linux",
+      "open-source",
+      "ci",
+      "cd",
+      "open-source"
+    ],
+    "url": "https://github.com/kubernetes/test-infra/tree/master/prow"
+  }
+]

--- a/data/tools/pulp.json
+++ b/data/tools/pulp.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "A platform for managing software package repositories",
+    "name": "Pulp",
+    "slug": "pulp",
+    "tags": [
+      "linux",
+      "open-source",
+      "packaging",
+      "python"
+    ],
+    "url": "http://www.pulpproject.org"
+  }
+]

--- a/data/tools/releaseiq.json
+++ b/data/tools/releaseiq.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "ReleaseIQ helps companies accelerate software product release cycles while improving quality and efficiency with an Enterprise DevOps Platform that leverages existing CI/CD tools",
+    "name": "ReleaseIQ",
+    "slug": "ReleaseIQ",
+    "tags": [
+      "linux",
+      "free",
+      "commercial",
+      "ci",
+      "cd",
+      "orchestration"
+    ],
+    "url": "https://www.releaseiq.io"
+  }
+]

--- a/data/tools/rhodecode.json
+++ b/data/tools/rhodecode.json
@@ -1,0 +1,14 @@
+[
+  {
+    "description": "Centralized control for distributed repositories. Mercurial, Git, and Subversion under a single roof",
+    "name": "RhodeCode",
+    "slug": "rhodecode",
+    "tags": [
+      "linux",
+      "open-source",
+      "scm",
+      "vcs"
+    ],
+    "url": "https://rhodecode.com"
+  }
+]

--- a/data/tools/rtk.json
+++ b/data/tools/rtk.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "rkt is an application container engine developed for modern production cloud-native environments. It features a pod-native approach, a pluggable execution environment, and a well-defined surface area that makes it ideal for integration with other systems.",
+    "name": "rtk",
+    "slug": "rtk",
+    "tags": [
+      "linux",
+      "open-source",
+      "virt"
+    ],
+    "url": "https://coreos.com/rkt/"
+  }
+]

--- a/data/tools/signalfx.json
+++ b/data/tools/signalfx.json
@@ -1,0 +1,20 @@
+[
+  {
+    "description": "SignalFx is an advanced monitoring and alerting solution for modern infrastructure. With SignalFx, development and operations teams monitor, analyze, and alert in real-time on any time series data.",
+    "name": "SignalFx",
+    "slug": "signalfx",
+    "tags": [
+      "linux",
+      "windows",
+      "oxs",
+      "commercial",
+      "go",
+      "python",
+      "c",
+      "metrics",
+      "monitoring",
+      "visualization"
+    ],
+    "url": "https://www.signalfx.com/"
+  }
+]

--- a/data/tools/simp.json
+++ b/data/tools/simp.json
@@ -1,0 +1,13 @@
+[
+  {
+    "description": "Compliance automation",
+    "name": "Simp",
+    "slug": "simp",
+    "tags": [
+      "linux",
+      "open-source",
+      "security"
+    ],
+    "url": "https://www.simp-project.com/"
+  }
+]

--- a/data/tools/skaffold.json
+++ b/data/tools/skaffold.json
@@ -1,0 +1,16 @@
+[
+  {
+    "description": "Skaffold handles the workflow for building, pushing and deploying your application. So you can focus more on application development.",
+    "name": "Skaffold",
+    "slug": "skaffolddev",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "ci",
+      "cd"
+    ],
+    "url": "https://skaffold.dev/"
+  }
+]

--- a/data/tools/snitch.json
+++ b/data/tools/snitch.json
@@ -1,0 +1,21 @@
+[
+  {
+    "description": "SaaS SSL monitoring and alerting. Snitch audits for revocation, expiration, changes to the certificate, known security vulnerabilities, and best practices. Snitch worries about your SSL/TLS certificate so you don't have to",
+    "name": "Snitch",
+    "slug": "snitch",
+    "tags": [
+      "monitoring",
+      "commercial",
+      "linux",
+      "windows",
+      "freebsd",
+      "bsd",
+      "solaris",
+      "osx",
+      "metrics",
+      "security",
+      "hardening"
+    ],
+    "url": "https://snitch.io"
+  }
+]

--- a/data/tools/tekton.json
+++ b/data/tools/tekton.json
@@ -1,0 +1,15 @@
+[
+  {
+    "description": " A Kubernetes-native pipeline resource. The Tekton Pipelines project provides Kubernetes-style resources for declaring CI/CD-style pipelines.",
+    "name": "Tekton",
+    "slug": "tekton",
+    "tags": [
+      "linux",
+      "open-source",
+      "ci",
+      "cd",
+      "kubernetes"
+    ],
+    "url": "https://tekton.dev/"
+  }
+]

--- a/data/tools/vault.json
+++ b/data/tools/vault.json
@@ -1,0 +1,18 @@
+[
+  {
+    "description": "Manage Secrets and Protect Sensitive Data. Secure, store and tightly control access to tokens, passwords, certificates, encryption keys for protecting secrets and other sensitive data using a UI, CLI, or HTTP API.",
+    "name": "Vault",
+    "slug": "Vault",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "bsd",
+      "solaris",
+      "open-source",
+      "comercial",
+      "security"
+    ],
+    "url": "https://www.vaultproject.io/"
+  }
+]

--- a/data/tools/werf.json
+++ b/data/tools/werf.json
@@ -1,0 +1,18 @@
+[
+  {
+    "description": "werf is CI/CD tool for building Docker images and delivering them to Kubernetes using a GitOps approach. It integrates with any existing CI systems including GitLab CI, GitHub Actions, etc.",
+    "name": "werf",
+    "slug": "werf",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "ci",
+      "kubernetes",
+      "virt",
+      "go"
+    ],
+    "url": "https://werf.io/"
+  }
+]


### PR DESCRIPTION
Some of these tools may have been removed, but given that devopsbookmarks.com won't be changing at all now, this at least makes this repo the canonical source of truth of the tools list.

The whole list probably needs a one by one review since so many projects appear to be unmaintained and would be good to pull from the list.